### PR TITLE
Update atmodem.lua

### DIFF
--- a/luasrc/controller/atmodem.lua
+++ b/luasrc/controller/atmodem.lua
@@ -9,7 +9,7 @@ end
 function webcmd()
     local cmd = http.formvalue("cmd")
     if cmd then
-	    local at = io.popen("/usr/bin/at " ..tostring(cmd).." 2>&1")
+	    local at = io.popen("/usr/bin/at " ..string.gsub(cmd, "\"", "\\\"").." 2>&1")
 	    local result =  at:read("*a")
 	    at:close()
         http.write(tostring(result))


### PR DESCRIPTION
add support of AT commands with double quotes, like AT!ENTERCND="A710"